### PR TITLE
20階層の動き

### DIFF
--- a/The_Climb/Assets/Script/Enemy/Boss_20/Boss_20_Controller.cs
+++ b/The_Climb/Assets/Script/Enemy/Boss_20/Boss_20_Controller.cs
@@ -1,8 +1,5 @@
 ﻿using UnityEngine;
 using System.Collections;
-using UnityEngine.InputSystem.Utilities;
-using System;
-using System.Net.Http.Headers;
 
 
 
@@ -12,6 +9,7 @@ public class Boss_20_Controller : MonoBehaviour
     public GameObject Bullet_Prefab;            //弾のPrehab
     public Transform Bullet_Position;　　　　　 //弾の発射位置
     public Transform Player;
+
 
     private int Enemy_Left_Max;                 //敵の移動は左の範囲
     private int Enemy_Right_Max;　　　　　　　　//敵の移動は右の範囲

--- a/The_Climb/Assets/Script/Enemy/Boss_20/Boss_20_Knockback.cs
+++ b/The_Climb/Assets/Script/Enemy/Boss_20/Boss_20_Knockback.cs
@@ -1,0 +1,64 @@
+using UnityEngine;
+using System.Collections;
+public class Boss_20_Knockback : MonoBehaviour
+{
+
+    [SerializeField] public Transform player;       // プレイヤーのTransform
+    [SerializeField] public float knockbackDistance = 5f; // 発動距離
+    [SerializeField] public float knockbackForce = 0.1f;    // ノックバックの力
+    [SerializeField] private float stopDuration = 0.2f;        // 停止している時間
+                     private bool isKnockbacking = false;                  // 移動を一時的に止めるフラグ
+
+    private Rigidbody rb;
+    private bool hasKnockedBack = false;
+
+    void Start()
+    {
+        rb = GetComponent<Rigidbody>();
+    }
+
+    void Update()
+    {
+        CheckPlayerDistance();
+    }
+
+    void CheckPlayerDistance()
+    {
+        if (player == null || rb == null) return;
+
+        float distance = Vector3.Distance(transform.position, player.position);
+
+        if (distance <= knockbackDistance && !hasKnockedBack)
+        {
+            ApplyKnockback();
+            hasKnockedBack = true;
+        }
+
+        // 一定以上離れたらノックバックを再び許可
+        if (distance > knockbackDistance + 1f)
+        {
+            hasKnockedBack = false;
+        }
+    }
+
+    void ApplyKnockback()
+    {
+        Debug.Log("ノックバック発動！");
+        Vector3 direction = (transform.position - player.position).normalized;
+        rb.AddForce(direction * knockbackForce, ForceMode.Impulse);
+
+        StartCoroutine(ResetVelocityAfterKnockback());
+    }
+
+    IEnumerator ResetVelocityAfterKnockback()
+    {
+        yield return new WaitForSeconds(knockbackDistance); // 少し時間を置く（力が加わった直後）
+
+        rb.linearVelocity = Vector3.zero;
+        rb.angularVelocity = Vector3.zero; // 回転も止めたい場合
+
+        yield return new WaitForSeconds(stopDuration);
+
+        isKnockbacking = false;
+    }
+}

--- a/The_Climb/Assets/Script/Enemy/Boss_20/Boss_20_Knockback.cs.meta
+++ b/The_Climb/Assets/Script/Enemy/Boss_20/Boss_20_Knockback.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6409b9bd332e4e140b36b8bd4de8d709


### PR DESCRIPTION
新規Script :
Boss_20_Knockback

変更Script : 変更内容
Boss_20_Knockback
プレイヤーが一定距離に近づくと敵が吹っ飛ぶ
バグ内容
休憩中吹っ飛ばない
理由　分かる
動いているときに吹っ飛ばすと、その威力がそのまま残って動き続ける

追加機能
ボスに頭突きすると、飛ぶようにした