### PR TITLE
闇 : 夜 : 狂暴化した敵とっ接触した場合

### DIFF
--- a/The_Climb/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Zenject-ReflectionBaking.csproj.meta
+++ b/The_Climb/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Zenject-ReflectionBaking.csproj.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 91b0b4c77fdd1d24aa1af646e9d29960
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/The_Climb/Assets/Plugins/Zenject/OptionalExtras/Signals/Zenject-Signals.csproj.meta
+++ b/The_Climb/Assets/Plugins/Zenject/OptionalExtras/Signals/Zenject-Signals.csproj.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aebd7ef925dd4fe4690c3238e879f914
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/The_Climb/Assets/Plugins/Zenject/Source/Zenject.csproj.meta
+++ b/The_Climb/Assets/Plugins/Zenject/Source/Zenject.csproj.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8645273165cb7f54290d6eaa1e10ab37
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/The_Climb/Assets/Script/Effect/Fade/FadeContoroller.cs
+++ b/The_Climb/Assets/Script/Effect/Fade/FadeContoroller.cs
@@ -33,6 +33,7 @@ public class FadeContoroller : MonoBehaviour, IDownFading
     //  フェードアウト処理
     public IEnumerator DownFading()
     {
+        FadeSetter.ApplyToSceneFadeQuad();
         while(CurrentProgress > 0)
         {
             CurrentProgress -= CurrentProgressRate_Sec * Time.deltaTime;


### PR DESCRIPTION
変更Script : 変更内容
FadeContoroller : フェード開始時闇の位置を移動
追加機能------------------
フェードを開始した一回だけ闇の位置を移動させる
確認方法------------------
BackGround内のFadeQuadを適当な位置にずらして、夜敵と接触した場合画面中央に1回だけ戻ってきたら成功